### PR TITLE
Add start time and duration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal, installable web-based calendar app for quick week/day/month views and
 - **Week / Day / Month views** toggle  
 - **One-off** and **simple recurring** events (daily/weekly/monthly)  
 - **LocalStorage** persistence—no external backend or phone-calendar syncing  
+- **Start time and duration** for each event
 - **PWA installable** (“Add to Home Screen”)  
 - **Offline support** via Service Worker  
 
@@ -75,6 +76,8 @@ http://localhost:8000
 4. In the **Add Event** modal:
    - Enter **Title**  
    - Pick a **Date**  
+   - Set a **Start Time**
+   - Specify **Duration** in minutes
    - Choose a **Recurrence** (None/Daily/Weekly/Monthly)  
    - **Save**  
 

--- a/app.js
+++ b/app.js
@@ -64,10 +64,11 @@ function makeCell(date, monthFilter) {
   lbl.textContent = date.getDate();
   cell.appendChild(lbl);
 
-  getEventsForDate(date).forEach(ev => {
-    const evEl = document.createElement('div');
-    evEl.className = 'event';
-    evEl.textContent = ev.title;
+  const events = getEventsForDate(date).slice().sort((a,b) => (a.startTime || "").localeCompare(b.startTime || ""));
+  events.forEach(ev => {
+    const evEl = document.createElement("div");
+    evEl.className = "event";
+    evEl.textContent = (ev.startTime ? ev.startTime + " " : "") + ev.title;
     cell.appendChild(evEl);
   });
   return cell;
@@ -133,9 +134,11 @@ document.getElementById('cancelEventBtn').onclick  = () => modal.classList.add('
 document.getElementById('saveEventBtn').onclick    = () => {
   const title      = document.getElementById('eventTitle').value.trim();
   const date       = document.getElementById('eventDate').value;
+  const startTime = document.getElementById("eventStart").value;
+  const duration = parseInt(document.getElementById("eventDuration").value,10)||0;
   const recurrence = document.getElementById('eventRecurrence').value;
   if (title && date) {
-    addEvent({ id: Date.now(), title, date, recurrence });
+    addEvent({ id: Date.now(), title, date, startTime, duration, recurrence });
     modal.classList.add('hidden');
     render();
   }

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
       <h2>Add Event</h2>
       <label>Title:<input id="eventTitle" type="text"></label>
       <label>Date:<input id="eventDate" type="date"></label>
+      <label>Start Time:<input id="eventStart" type="time"></label>
+      <label>Duration (mins):<input id="eventDuration" type="number" min="1" value="60"></label>
       <label>Recurrence:
         <select id="eventRecurrence">
           <option value="none">None</option>


### PR DESCRIPTION
## Summary
- allow specifying start time and duration when creating an event
- sort events by start time and show the time in the calendar
- document new fields in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aa9cb0a848320a3c103b32f636a4d